### PR TITLE
Connect contact form to Formspree

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -4,7 +4,7 @@ import { useTranslations } from '../i18n/utils';
 interface Props { lang: Lang }
 const { lang } = Astro.props;
 const t = useTranslations(lang);
-const FORMSPREE_ENDPOINT = 'https://formspree.io/f/REPLACE_ME';
+const FORMSPREE_ENDPOINT = 'https://formspree.io/f/xqeozqev';
 ---
 <section id="contact" class="border-t border-[var(--color-line-accent)] bg-accent/[0.03]">
   <div class="mx-auto max-w-5xl px-5 py-20">


### PR DESCRIPTION
Wires the contact form to the live Formspree endpoint (f/xqeozqev → taverna.lucas@gmail.com). First real submission triggers Formspree's one-time email confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)