### PR TITLE
Typography polish: heading tracking + tabular figures

### DIFF
--- a/src/components/Cases.astro
+++ b/src/components/Cases.astro
@@ -9,7 +9,7 @@ const t = useTranslations(lang);
 <section id="cases" class="border-t border-[var(--color-line)]">
   <div class="mx-auto max-w-5xl px-5 py-20">
     <p class="font-mono text-xs text-accent">{t('cases.kicker')}</p>
-    <h2 class="mt-1 text-2xl font-bold text-white md:text-3xl">{t('cases.title')}</h2>
+    <h2 class="mt-1 text-2xl font-bold tracking-tight text-white md:text-3xl">{t('cases.title')}</h2>
 
     <div class="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
       {caseStudies.map((c) => (
@@ -30,7 +30,7 @@ const t = useTranslations(lang);
 
           <div class="mt-5 border-t border-[var(--color-line)] pt-4">
             <span class="font-mono text-[11px] uppercase tracking-wider text-accent">{t('cases.results')}</span>
-            <ul class="mt-2 space-y-1">
+            <ul class="mt-2 space-y-1 tabular-nums">
               {c[lang].results.map((r) => (
                 <li class="flex gap-2 text-sm text-gray-200">
                   <span class="text-accent">▸</span>{r}

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -9,7 +9,7 @@ const FORMSPREE_ENDPOINT = 'https://formspree.io/f/xqeozqev';
 <section id="contact" class="border-t border-[var(--color-line-accent)] bg-accent/[0.03]">
   <div class="mx-auto max-w-5xl px-5 py-20">
     <p class="font-mono text-xs text-accent">{t('contact.kicker')}</p>
-    <h2 class="mt-1 text-2xl font-bold text-white md:text-3xl">{t('contact.title')}</h2>
+    <h2 class="mt-1 text-2xl font-bold tracking-tight text-white md:text-3xl">{t('contact.title')}</h2>
     <form action={FORMSPREE_ENDPOINT} method="POST" class="mt-8 max-w-xl">
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <input

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -12,7 +12,7 @@ const t = useTranslations(lang);
   ></div>
   <div class="relative mx-auto max-w-5xl px-5 py-24 md:py-32">
     <p class="mb-4 font-mono text-sm text-accent">● {t('hero.prompt')}</p>
-    <h1 class="max-w-2xl text-4xl font-extrabold leading-tight text-white md:text-6xl">
+    <h1 class="max-w-2xl text-4xl font-extrabold leading-[1.05] tracking-tight text-white md:text-6xl">
       {t('hero.titleA')}<span class="text-accent glow-accent">{t('hero.titleAccent')}</span>{t('hero.titleB')}
     </h1>
     <p class="mt-5 max-w-xl text-base text-gray-400 md:text-lg">{t('hero.subtitle')}</p>

--- a/src/components/Process.astro
+++ b/src/components/Process.astro
@@ -9,7 +9,7 @@ const t = useTranslations(lang);
 <section id="process" class="border-t border-[var(--color-line)]">
   <div class="mx-auto max-w-5xl px-5 py-20">
     <p class="font-mono text-xs text-accent">{t('process.kicker')}</p>
-    <h2 class="mt-1 text-2xl font-bold text-white md:text-3xl">{t('process.title')}</h2>
+    <h2 class="mt-1 text-2xl font-bold tracking-tight text-white md:text-3xl">{t('process.title')}</h2>
     <div class="mt-8 grid grid-cols-1 gap-3 font-mono text-sm sm:grid-cols-2 lg:grid-cols-4">
       {processSteps.map((p, i) => (
         <div class={`border-l-2 ${i === 0 ? 'border-accent' : 'border-gray-700'} px-4 py-2`}>

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -10,7 +10,7 @@ const t = useTranslations(lang);
 <section id="services" class="border-t border-[var(--color-line)]">
   <div class="mx-auto max-w-5xl px-5 py-20">
     <p class="font-mono text-xs text-accent">{t('services.kicker')}</p>
-    <h2 class="mt-1 text-2xl font-bold text-white md:text-3xl">{t('services.title')}</h2>
+    <h2 class="mt-1 text-2xl font-bold tracking-tight text-white md:text-3xl">{t('services.title')}</h2>
     <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {services.map((s, i) => <ServiceCard service={s} lang={lang} featured={i === 0} />)}
     </div>

--- a/src/components/Stack.astro
+++ b/src/components/Stack.astro
@@ -10,7 +10,7 @@ const t = useTranslations(lang);
   <div class="mx-auto max-w-5xl px-5 py-20">
     <p class="font-mono text-xs text-accent">{t('stack.kicker')}</p>
 
-    <h2 class="mt-1 text-2xl font-bold text-white md:text-3xl">{t('expertise.title')}</h2>
+    <h2 class="mt-1 text-2xl font-bold tracking-tight text-white md:text-3xl">{t('expertise.title')}</h2>
     <div class="mt-6 flex flex-wrap gap-2 font-mono text-sm">
       {areasOfExpertise.map((area) => (
         <span class="rounded border border-[var(--color-line-accent)] px-3 py-1 text-gray-200">{area}</span>


### PR DESCRIPTION
Adds negative letter-spacing and tighter leading to the hero display and section headings (the 'Inter premium' recipe), and tabular-nums to case-study metrics. No font change — Inter + JetBrains Mono confirmed correct for this register. Tests + check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)